### PR TITLE
move tensors to the same device

### DIFF
--- a/lmm_engines/huggingface/model/model_videollava.py
+++ b/lmm_engines/huggingface/model/model_videollava.py
@@ -99,6 +99,7 @@ class VideoLLaVAAdapter(BaseModelAdapter):
 
         final_prompt = f"USER: <video>{prompt} ASSISTANT:"
         inputs = self.processor(text=final_prompt, videos=clip, return_tensors="pt")
+        inputs = {k: v.to(self.model.device) for k, v in inputs.items()}
 
         # Generate
         generate_ids = self.model.generate(**inputs, **generation_kwargs)
@@ -158,7 +159,7 @@ if __name__ == "__main__":
     from .unit_test import test_adapter
     from PIL import Image
     model_path = "LanguageBind/Video-LLaVA-7B-hf"
-    device = "cuda:0"
+    device = "cuda"
     model_adapter = VideoLLaVAAdapter()
     test_adapter(model_adapter, model_path, device, model_type="video")
     


### PR DESCRIPTION
1. There exists an error when local testing ```model_videollava.py```:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! (when checking argument for argument index in method wrapper_CUDA__index_select)
```
Fix this by moving inputs to ```device``` in ```generate()``` function.

2. When ```device = "cuda:0"```, there exists an error in line 270 in ```LMM-Engines/lmm_engines/huggingface/model/model_adapter.py```:
```
ValueError: Invalid device: cuda:0
```
Fix this by setting ```device = "cuda"```.