### PR TITLE
add cogvlm2-video model

### DIFF
--- a/lmm_engines/huggingface/model/dummy_image_model.py
+++ b/lmm_engines/huggingface/model/dummy_image_model.py
@@ -94,7 +94,7 @@ class DummyImageAdapter(BaseModelAdapter):
     
     def get_info(self):
         return {
-            "type": "video",
+            "type": "image",
             "author": "Anonymous",
             "organization": "Anonymous",
             "model_size": None,

--- a/lmm_engines/huggingface/model/dummy_video_model.py
+++ b/lmm_engines/huggingface/model/dummy_video_model.py
@@ -71,7 +71,7 @@ class DummyVideoAdapter(BaseModelAdapter):
         params:dict = {
             "prompt": {
                 "text": str,
-                "image": str, # base64 image
+                "video": str, # base64 encoded video
             },
             **generation_kwargs # other generation kwargs, like temperature, top_p, max_new_tokens, etc.
         }

--- a/lmm_engines/huggingface/model/model_adapter.py
+++ b/lmm_engines/huggingface/model/model_adapter.py
@@ -397,7 +397,7 @@ def remove_parent_directory_name(model_path):
 from .model_instructblip import InstructBLIPAdapter
 from .model_claude import ClaudeAdapter
 from .model_openai import OpenAIAdapter
-from .model_cogvlm import CogVLMAdapter
+from .model_cogvlm import CogVLMAdapter, CogVLM2VideoAdapter
 from .model_llavaapi import LlavaAPIAdapter
 from .model_gemini import GeminiAdapter
 from .model_llava_v1_5 import LLaVAv15Adapter
@@ -438,6 +438,7 @@ register_model_adapter(LLaVAv16Adapter)
 register_model_adapter(QwenVLAdapter)
 register_model_adapter(InstructBLIPAdapter)
 register_model_adapter(CogVLMAdapter)
+register_model_adapter(CogVLM2VideoAdapter)
 register_model_adapter(MiniCPMAdapter)
 register_model_adapter(UFormAdapter)
 register_model_adapter(DeepSeekVLAdapter)

--- a/lmm_engines/huggingface/model/model_cogvlm.py
+++ b/lmm_engines/huggingface/model/model_cogvlm.py
@@ -6,9 +6,11 @@ import base64
 from io import BytesIO
 from .model_adapter import BaseModelAdapter, register_model_adapter
 from ..conversation import get_conv_template, Conversation
-from ...utils import decode_image
+from ...utils import decode_image, decode_and_save_video
+from .videollm_utils.cogvlm.utils import load_video
 from transformers import CLIPImageProcessor
 from transformers import InstructBlipProcessor, InstructBlipForConditionalGeneration
+from transformers import TextIteratorStreamer, AutoTokenizer, AutoModelForCausalLM
 from threading import Thread
 from typing import List
 
@@ -16,7 +18,7 @@ class CogVLMAdapter(BaseModelAdapter):
     """The model adapter for CogVLM"""
 
     def match(self, model_path: str):
-        return "cogvlm" in model_path.lower()
+        return "cogvlm" in model_path.lower() and "cogvlm2-video-llama3-chat" not in model_path.lower()
 
     def get_default_conv_template(self, model_path: str) -> Conversation:
         return get_conv_template("cogvlm")
@@ -30,13 +32,152 @@ class CogVLMAdapter(BaseModelAdapter):
     def generate_stream(self, params:dict):
         pass
     
+class CogVLM2VideoAdapter(BaseModelAdapter):
+    """The model adapter for CogVLM2Video"""
+
+    def match(self, model_path: str):
+        return "cogvlm2-video-llama3-chat" in model_path.lower()
+
+    def load_model(self, model_path: str, device:str="cuda", from_pretrained_kwargs: dict={}):
+        """
+        load all the elements of the models here that will be used for your model's geneation, such as the model, tokenizer, processor, etc.
+        Args:
+            model_path (str): the path to the model, huggingface model id or local path
+            device (str): the device to run the model on
+            from_pretrained_kwargs (dict): other kwargs to pass to the from_pretrained method.
+                It's better to ignore this one, and set your custom kwargs in the load_model method.
+        Returns:
+            model: A nn.Module model or huggingface PreTrainedModel model
+        """
+        # from_pretrained_kwargs["torch_dtype"] = torch.float16
+        self.torch_type = torch.bfloat16 if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8 else torch.float16
+        from_pretrained_kwargs["torch_dtype"] = self.torch_type
+        from_pretrained_kwargs["low_cpu_mem_usage"] = True
+        from_pretrained_kwargs["trust_remote_code"] = True
+        self.model = AutoModelForCausalLM.from_pretrained(
+            model_path, **from_pretrained_kwargs
+        ).eval()
+        self.tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+        
+        return self.model
     
+    def generate(self, params:dict):
+        """
+        generation
+        Args:
+            params:dict = {
+                "prompt": {
+                    "text": str,
+                    "video": str, # base64 encoded video
+                },
+                **generation_kwargs # other generation kwargs, like temperature, top_p, max_new_tokens, etc.
+            }
+        Returns:
+            {"text": ...}
+        """
+        # add your custom generation code here
+        video_path = decode_and_save_video(params["prompt"]["video"]) # This will save the video to a file and return the path
+        prompt = params["prompt"]["text"]
+        generation_kwargs = params.copy()
+        generation_kwargs.pop("prompt")
+        strategy = "chat"
+        video = load_video(video_path, strategy=strategy)
+
+        history = []
+        inputs = self.model.build_conversation_input_ids(
+            tokenizer = self.tokenizer,
+            query = prompt,
+            images = [video],
+            history = history,
+            template_version = strategy
+        )
+        inputs = {
+            'input_ids': inputs['input_ids'].unsqueeze(0).to('cuda'),
+            'token_type_ids': inputs['token_type_ids'].unsqueeze(0).to('cuda'),
+            'attention_mask': inputs['attention_mask'].unsqueeze(0).to('cuda'),
+            'images': [[inputs['images'][0].to(self.model.device).to(self.torch_type)]],
+        }
+        # gen_kwargs = {
+        # "max_new_tokens": 2048,
+        # "pad_token_id": 128002,
+        # "top_k": 1,
+        # "do_sample": False,
+        # "top_p": 0.1,
+        # "temperature": temperature,
+        # }
+        with torch.no_grad():
+            outputs = self.model.generate(**inputs, **generation_kwargs)
+            outputs = outputs[:, inputs['input_ids'].shape[1]:]
+            response = self.tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+        return {"text": response}
+        
+    def generate_stream(self, params:dict):
+        """
+        params:dict = {
+            "prompt": {
+                "text": str,
+                "video": str, # base64 encoded video
+            },
+            **generation_kwargs # other generation kwargs, like temperature, top_p, max_new_tokens, etc.
+        }
+        """
+        video_path = decode_and_save_video(params["prompt"]["video"]) # This will save the video to a file and return the path
+        prompt = params["prompt"]["text"]
+        generation_kwargs = params.copy()
+        generation_kwargs.pop("prompt")
+        strategy = "chat"
+        video = load_video(video_path, strategy=strategy)
+
+        history = []
+        inputs = self.model.build_conversation_input_ids(
+            tokenizer = self.tokenizer,
+            query = prompt,
+            images = [video],
+            history = history,
+            template_version = strategy
+        )
+        inputs = {
+            'input_ids': inputs['input_ids'].unsqueeze(0).to('cuda'),
+            'token_type_ids': inputs['token_type_ids'].unsqueeze(0).to('cuda'),
+            'attention_mask': inputs['attention_mask'].unsqueeze(0).to('cuda'),
+            'images': [[inputs['images'][0].to(self.model.device).to(self.torch_type)]],
+        }
+
+        # add streamer
+        streamer = TextIteratorStreamer(self.tokenizer, skip_prompt=True, skip_special_tokens=True)
+        generation_kwargs["streamer"] = streamer
+
+        # Start the model chat in a separate thread
+        thread = Thread(target=self.model.generate, kwargs={**inputs, **generation_kwargs})
+        thread.start()
+        
+        generated_text = ""
+        for text in streamer:
+            generated_text += text
+            yield {"text": generated_text}
+            
+    def get_info(self):
+        return {
+            "type": "video",
+            "author": "Weihan Wang and Qingsong Lv and Wenmeng Yu and Wenyi Hong and Ji Qi and Yan Wang and Junhui Ji and Zhuoyi Yang and Lei Zhao and Xixuan Song and Jiazheng Xu and Bin Xu and Juanzi Li and Yuxiao Dong and Ming Ding and Jie Tang",
+            "organization": "THUDM",
+            "model_size": "8B",
+            "model_link": "https://huggingface.co/THUDM/cogvlm2-video-llama3-chat",
+        }
+
+
 if __name__ == "__main__":
     from .unit_test import test_adapter
     from PIL import Image
-    model_path = "..."
-    device = "cuda:0"
-    model_adapter = CogVLMAdapter()
+    # model_path = "..."
+    # device = "cuda"
+    # model_adapter = CogVLMAdapter()
+    # test_adapter(model_adapter, model_path, device)
+
+    model_path = "THUDM/cogvlm2-video-llama3-chat"
+    device = "cuda"
+    model_adapter = CogVLM2VideoAdapter()
     test_adapter(model_adapter, model_path, device)
 """
 python -m lmm_engines.huggingface.model.model_cogvlm

--- a/lmm_engines/huggingface/model/videollm_utils/cogvlm/README.md
+++ b/lmm_engines/huggingface/model/videollm_utils/cogvlm/README.md
@@ -1,0 +1,7 @@
+# CogVLM2
+Please create a new conda environment for cogvlm2 models and install the ```requirements.txt``` in this folder ```lmm_engines/huggingface/model/videollm_utils/cogvlm```.
+```shell
+conda create -n cogvlm python=3.10
+conda activate cogvlm
+pip install -r requirements.txt
+```

--- a/lmm_engines/huggingface/model/videollm_utils/cogvlm/requirements.txt
+++ b/lmm_engines/huggingface/model/videollm_utils/cogvlm/requirements.txt
@@ -1,0 +1,26 @@
+decord>=0.6.0
+torch==2.1.0
+torchvision== 0.16.0
+pytorchvideo==0.1.5
+xformers
+transformers==4.42.4
+huggingface-hub>=0.23.0
+pillow
+chainlit>=1.0
+pydantic>=2.7.1
+timm>=0.9.16
+openai>=1.30.1
+loguru>=0.7.2
+pydantic>=2.7.1
+einops
+sse-starlette>=2.1.0
+flask
+gunicorn
+gevent
+requests
+gradio
+psutil
+datasets
+icecream
+opencv-python
+accelerate

--- a/lmm_engines/huggingface/model/videollm_utils/cogvlm/utils.py
+++ b/lmm_engines/huggingface/model/videollm_utils/cogvlm/utils.py
@@ -1,0 +1,37 @@
+import io
+import numpy as np
+import torch
+from decord import cpu, VideoReader, bridge
+
+def load_video(video_path, strategy='chat'):
+    bridge.set_bridge('torch')
+    num_frames = 24
+    decord_vr = VideoReader(video_path, ctx=cpu(0))
+
+    frame_id_list = None
+    total_frames = len(decord_vr)
+    if strategy == 'base':
+        clip_end_sec = 60
+        clip_start_sec = 0
+        start_frame = int(clip_start_sec * decord_vr.get_avg_fps())
+        end_frame = min(total_frames,
+                        int(clip_end_sec * decord_vr.get_avg_fps())) if clip_end_sec is not None else total_frames
+        frame_id_list = np.linspace(start_frame, end_frame - 1, num_frames, dtype=int)
+    elif strategy == 'chat':
+        timestamps = decord_vr.get_frame_timestamp(np.arange(total_frames))
+        timestamps = [i[0] for i in timestamps]
+        max_second = round(max(timestamps)) + 1
+        frame_id_list = []
+        for second in range(max_second):
+            closest_num = min(timestamps, key=lambda x: abs(x - second))
+            index = timestamps.index(closest_num)
+            frame_id_list.append(index)
+            if len(frame_id_list) >= num_frames:
+                break
+
+        # while len(frame_id_list) < num_frames:
+        #     frame_id_list.append(frame_id_list[-1])
+
+    video_data = decord_vr.get_batch(frame_id_list)
+    video_data = video_data.permute(3, 0, 1, 2)
+    return video_data


### PR DESCRIPTION
1. Fix a bug in get_info() in dummy_image_model
2. Add cogvlm2-video model. To run cogvlm2-video models, please check out ```lmm_engines/huggingface/model/videollm_utils/cogvlm/README.md``` to create a separate environment, as many packages used in cogvlm2 are specific versions.